### PR TITLE
v1.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
-## 🧩 Addon Updates (2026-04-20)
+## 🧩 Addon Updates (2026-04-21)
 
-**Mythic Dungeon Teleports** — v1.27  
+**Mythic Dungeon Teleports** — v1.27.1  
 
 **Changes:**  
-- Added 12.0.5 ready for patch    
-- Added a new **Auto Invites** Quality of Life module. This allows the addon to automatically invite players when they whisper you with one of your chosen keywords. You can enable or disable it, set one or multiple keywords such as `inv, invite, 123`, and restrict who it works for with options including **Anyone**, **Friends**, **Guild**, or **Friends & Guild**. It also supports both normal in-game whispers and Battle.net whispers.    
+- Added 12.0.5 ready for patch  
+- Added a new **Auto Invites** Quality of Life module. This allows the addon to automatically invite players when they whisper you with one of your chosen keywords. You can enable or disable it, set one or multiple keywords such as `inv, invite, 123`, and restrict who it works for with options including **Anyone**, **Friends**, **Guild**, or **Friends & Guild**. It supports both normal in-game whispers and Battle.net whispers.  
+- Auto Invites now respects gameplay restrictions and will not trigger while in combat, raids, or active Mythic+ to ensure safe and consistent behaviour with the rest of the addon.  
 
 **Fixes:**  
-- None currently known.
+- Fixed a taint-related error that could occur when processing whisper messages for Auto Invites.  
 
 **Known issues:**  
 - None currently known.

--- a/DungeonTeleports.toc
+++ b/DungeonTeleports.toc
@@ -3,7 +3,7 @@
 ## Notes: Adds teleport buttons for M+ Dungeons & Raids
 ## Notes-ruRU: Добавляет кнопки телепортации для M+ подземелий и рейдов
 ## Author: Lanni-Alonsus
-## Version: 1.27
+## Version: 1.27.1
 
 ## X-Curse-Project-ID: 1194926
 ## X-Wago-ID: BNBeblGx

--- a/Modules/QoL.lua
+++ b/Modules/QoL.lua
@@ -34,8 +34,40 @@ end
 
 local function NormaliseKeyword(text)
   if type(text) ~= "string" then return "" end
-  text = text:match("^%s*(.-)%s*$") or ""
-  return text:lower()
+
+  local okTrim, trimmed = pcall(string.match, text, "^%s*(.-)%s*$")
+  if not okTrim or type(trimmed) ~= "string" then
+    return ""
+  end
+
+  local okLower, lowered = pcall(string.lower, trimmed)
+  if not okLower or type(lowered) ~= "string" then
+    return ""
+  end
+
+  return lowered
+end
+
+local function IsAutoInviteAllowedHere()
+  -- Match the addon's existing safety gating for risky behaviour.
+  if InCombatLockdown and InCombatLockdown() then return false end
+  if UnitAffectingCombat and UnitAffectingCombat("player") then return false end
+  if IsEncounterInProgress and IsEncounterInProgress() then return false end
+
+  -- Respect the addon's own Mythic+ suppression flag if present.
+  if addon and addon._DT_mplus_suppressed then return false end
+
+  -- Disable in raids always.
+  local inInstance, instanceType = IsInInstance()
+  if inInstance and instanceType == "raid" then return false end
+
+  -- Disable in active Mythic+ (Challenge Mode).
+  if C_ChallengeMode and C_ChallengeMode.IsChallengeModeActive then
+    local ok, active = pcall(C_ChallengeMode.IsChallengeModeActive)
+    if ok and active then return false end
+  end
+
+  return true
 end
 
 local function GetInviteKeywords()
@@ -257,6 +289,7 @@ whisperFrame:RegisterEvent("CHAT_MSG_BN_WHISPER")
 whisperFrame:SetScript("OnEvent", function(_, event, ...)
   local db = GetDB()
   if not db.autoInviteOnWhisper then return end
+  if not IsAutoInviteAllowedHere() then return end
 
   if event == "CHAT_MSG_WHISPER" then
     local message, sender = ...


### PR DESCRIPTION
Auto Invites now respects gameplay restrictions and will not trigger while in combat, raids, or active Mythic+ to ensure safe and consistent behaviour with the rest of the addon.  
